### PR TITLE
Migrate to April 12, 2016 snapshot

### DIFF
--- a/Sources/AsyncServer.swift
+++ b/Sources/AsyncServer.swift
@@ -1,9 +1,9 @@
 public protocol AsyncServer {
-    func serve(responder: AsyncResponder, on host: String, at port: Int) throws
+    func serve(_ responder: AsyncResponder, on host: String, at port: Int) throws
 }
 
 extension AsyncServer {
-    public func serve(responder: AsyncResponder, at port: Int) throws {
+    public func serve(_ responder: AsyncResponder, at port: Int) throws {
         try self.serve(responder, on: "0.0.0.0", at: port)
     }
 }

--- a/Sources/Header.swift
+++ b/Sources/Header.swift
@@ -22,7 +22,7 @@ extension Header: RangeReplaceableCollection, MutableCollection {
     }
 
     #if swift(>=3.0)
-    public mutating func replaceSubrange<C : Collection where C.Iterator.Element == String>(subRange: Range<Int>, with newElements: C) {
+    public mutating func replaceSubrange<C : Collection where C.Iterator.Element == String>(_ subRange: Range<Int>, with newElements: C) {
         self.values.replaceSubrange(subRange, with: newElements)
     }
     #else

--- a/Sources/RequestParser.swift
+++ b/Sources/RequestParser.swift
@@ -1,3 +1,3 @@
 public protocol RequestParser {
-    func parse(data: Data) throws -> Request?
+    func parse(_ data: Data) throws -> Request?
 }

--- a/Sources/RequestSerializer.swift
+++ b/Sources/RequestSerializer.swift
@@ -1,3 +1,3 @@
 public protocol RequestSerializer {
-    func serialize(request: Request, to stream: Stream) throws
+    func serialize(_ request: Request, to stream: Stream) throws
 }

--- a/Sources/ResponseParser.swift
+++ b/Sources/ResponseParser.swift
@@ -1,3 +1,3 @@
 public protocol ResponseParser {
-    func parse(data: Data) throws -> Response?
+    func parse(_ data: Data) throws -> Response?
 }

--- a/Sources/ResponseSerializer.swift
+++ b/Sources/ResponseSerializer.swift
@@ -1,3 +1,3 @@
 public protocol ResponseSerializer {
-    func serialize(response: Response, to stream: Stream) throws
+    func serialize(_ response: Response, to stream: Stream) throws
 }

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -1,5 +1,5 @@
 public protocol Server {
-    func serve(responder: Responder, on host: String, at port: Int) throws
+    func serve(_ responder: Responder, on host: String, at port: Int) throws
 }
 
 extension Server {

--- a/Tests/S4/BodyTests.swift
+++ b/Tests/S4/BodyTests.swift
@@ -33,7 +33,7 @@ class BodyTests: XCTestCase {
         testBodyProperties(buffer)
     }
 
-    private func testBodyProperties(body: Body) {
+    private func testBodyProperties(_ body: Body) {
         var bodyForBuffer = body
         var bodyForReceiver = body
         var bodyForSender = body


### PR DESCRIPTION
The biggest API change in this new snapshot is that `_` is not implicit for first parameters, so we have to add them explicitly to maintain the former behaviour.