### PR TITLE
Added WebSocket boolean that enables better support for websockets.

### DIFF
--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -5,6 +5,7 @@ public struct Request: Message {
     public var headers: Headers
     public var body: Body
     public var storage: [String: Any] = [:]
+    public var isWebSocket: Bool = false
 
     public init(method: Method, uri: URI, version: Version, headers: Headers, body: Body) {
         self.method = method


### PR DESCRIPTION
The most concrete example of the problem is Vapor.
Vapor takes a `Request`.. parses it as HTTP and then passes the resulting information to the `Middleware`. Of course it's not necessary that the stream is the body stream. It can be a WebSocket stream which will leave the HTTP Parser clueless. I think adding a `isWebSocket` boolean will allow WebSocket middlewares to transform a request to WebSocket whilst allowing it to notify any HTTP Server of the socket being transformed