### PR TITLE
Add async receiver/sender cases for Body

### DIFF
--- a/Sources/Body.swift
+++ b/Sources/Body.swift
@@ -26,7 +26,7 @@ public enum Body {
     case receiver(Stream)
     case sender((Stream) throws -> Void)
     case asyncReceiver(AsyncStream)
-    case asyncSender((AsyncStream, (Void throws -> Void) -> Void) -> Void)
+    case asyncSender((AsyncStream, ((Void) throws -> Void) -> Void) -> Void)
 }
 
 public enum BodyError: ErrorProtocol {
@@ -120,7 +120,7 @@ extension Body {
         case .sender(let sender):
             return sender
         default:
-            let closure: (Stream throws -> Void) = { _ in
+            let closure: ((Stream) throws -> Void) = { _ in
                 throw BodyError.inconvertibleType
             }
             return closure
@@ -143,7 +143,7 @@ extension Body {
      If the body is a receiver, sender, asyncReceiver or asyncSender type,
      it will be drained.
      */
-    public mutating func asyncBecomeBuffer(timingOut deadline: Double = .never, completion: (Void throws -> (Body, Data)) -> Void) {
+    public mutating func asyncBecomeBuffer(timingOut deadline: Double = .never, completion: ((Void) throws -> (Body, Data)) -> Void) {
         switch self {
         case .asyncReceiver(let stream):
             _ = AsyncDrain(for: stream, timingOut: deadline) { closure in
@@ -184,7 +184,7 @@ extension Body {
      Converts the body's contents into a `AsyncStream`
      that can be received in chunks.
      */
-    public mutating func becomeAsyncReceiver(completion: (Void throws -> (Body, AsyncStream)) -> Void) {
+    public mutating func becomeAsyncReceiver(completion: ((Void) throws -> (Body, AsyncStream)) -> Void) {
         switch self {
         case .asyncReceiver(let stream):
             completion {
@@ -216,11 +216,11 @@ extension Body {
      Converts the body's contents into a closure
      that accepts a `AsyncStream`.
      */
-    public mutating func becomeAsyncSender(timingOut deadline: Double = .never, completion: (Void throws -> (Body, ((AsyncStream, (Void throws -> Void) -> Void) -> Void))) -> Void) {
+    public mutating func becomeAsyncSender(timingOut deadline: Double = .never, completion: ((Void) throws -> (Body, ((AsyncStream, ((Void) throws -> Void) -> Void) -> Void))) -> Void) {
         
         switch self {
         case .buffer(let data):
-            let closure: ((AsyncStream, (Void throws -> Void) -> Void) -> Void) = { sender, result in
+            let closure: ((AsyncStream, ((Void) throws -> Void) -> Void) -> Void) = { sender, result in
                 sender.send(data, timingOut: deadline) { closure in
                     result {
                         try closure()
@@ -232,7 +232,7 @@ extension Body {
                 return (self, closure)
             }
         case .asyncReceiver(let receiver):
-            let closure: ((AsyncStream, (Void throws -> Void) -> Void) -> Void) = { sender, result in
+            let closure: ((AsyncStream, ((Void) throws -> Void) -> Void) -> Void) = { sender, result in
                 _ = AsyncDrain(for: receiver, timingOut: deadline) {
                     do {
                         let drain = try $0()

--- a/Sources/Body.swift
+++ b/Sources/Body.swift
@@ -4,21 +4,33 @@
     An HTTP message body contains the bytes of data that
     are transmitted immediately following the headers.
 
-    - buffer:   Simplest type of HTTP message body.
-                Represents a `Data` object containing
-                a byte array.
+    - buffer:        Simplest type of HTTP message body.
+                     Represents a `Data` object containing
+                     a byte array.
 
-    - receiver: Contains a `Stream` that can be drained
-                in chunks to access the body's data.
+    - receiver:      Contains a `Stream` that can be drained
+                     in chunks to access the body's data.
 
-    - sender:   Contains a closure that accepts a `Stream`
-                object to which the body's data should be sent.
-
+    - sender:        Contains a closure that accepts a `Stream`
+                     object to which the body's data should be sent.
+ 
+    - asyncReceiver: Contains a `AsyncStream` that can be drained
+                     in chunks to access the body's data.
+ 
+    - asyncSender:   Contains a closure that accepts a `AsyncStream`
+                     object to which the body's data should be sent.
+ 
 */
 public enum Body {
     case buffer(Data)
     case receiver(Stream)
     case sender((Stream) throws -> Void)
+    case asyncReceiver(AsyncStream)
+    case asyncSender((AsyncStream, (Void throws -> Void) -> Void) -> Void)
+}
+
+public enum BodyError: ErrorProtocol {
+    case inconvertibleType
 }
 
 extension Body {
@@ -43,6 +55,8 @@ extension Body {
 
             self = .buffer(data)
             return data
+        default:
+            throw BodyError.inconvertibleType
         }
     }
 
@@ -71,6 +85,8 @@ extension Body {
             try sender(stream)
             self = .receiver(stream)
             return stream
+        default:
+            throw BodyError.inconvertibleType
         }
     }
 
@@ -103,6 +119,11 @@ extension Body {
             return closure
         case .sender(let sender):
             return sender
+        default:
+            let closure: (Stream throws -> Void) = { _ in
+                throw BodyError.inconvertibleType
+            }
+            return closure
         }
     }
 
@@ -110,6 +131,138 @@ extension Body {
     public var isSender: Bool {
         switch self {
         case .sender: return true
+        default: return false
+        }
+    }
+}
+
+extension Body {
+    /**
+     Converts the body's contents into a `Data` buffer asynchronously.
+     
+     If the body is a receiver, sender, asyncReceiver or asyncSender type,
+     it will be drained.
+     */
+    public mutating func asyncBecomeBuffer(timingOut deadline: Double = .never, completion: (Void throws -> (Body, Data)) -> Void) {
+        switch self {
+        case .asyncReceiver(let stream):
+            _ = AsyncDrain(for: stream, timingOut: deadline) { closure in
+                completion {
+                    let drain = try closure ()
+                    self = .buffer(drain.data)
+                    return (self, drain.data)
+                }
+            }
+            
+        case .asyncSender(let sender):
+            let drain = AsyncDrain()
+            sender(drain) { closure in
+                completion {
+                    try closure()
+                    self = .buffer(drain.data)
+                    return (self, drain.data)
+                }
+            }
+        default:
+            completion {
+                let data = try self.becomeBuffer(timingOut: deadline)
+                return (self, data)
+            }
+        }
+    }
+    
+    ///Returns true if body is case `asyncReceiver`
+    public var isAsyncReceiver: Bool {
+        switch self {
+        case .asyncReceiver: return true
+        default: return false
+        }
+    }
+    
+    
+    /**
+     Converts the body's contents into a `AsyncStream`
+     that can be received in chunks.
+     */
+    public mutating func becomeAsyncReceiver(completion: (Void throws -> (Body, AsyncStream)) -> Void) {
+        switch self {
+        case .asyncReceiver(let stream):
+            completion {
+                (self, stream)
+            }
+        case .buffer(let data):
+            let stream = AsyncDrain(for: data)
+            self = .asyncReceiver(stream)
+            completion {
+                (self, stream)
+            }
+        case .asyncSender(let sender):
+            let stream = AsyncDrain()
+            sender(stream) { closure in
+                completion {
+                    try closure()
+                    self = .asyncReceiver(stream)
+                    return (self, stream)
+                }
+            }
+        default:
+            completion {
+                throw BodyError.inconvertibleType
+            }
+        }
+    }
+    
+    /**
+     Converts the body's contents into a closure
+     that accepts a `AsyncStream`.
+     */
+    public mutating func becomeAsyncSender(timingOut deadline: Double = .never, completion: (Void throws -> (Body, ((AsyncStream, (Void throws -> Void) -> Void) -> Void))) -> Void) {
+        
+        switch self {
+        case .buffer(let data):
+            let closure: ((AsyncStream, (Void throws -> Void) -> Void) -> Void) = { sender, result in
+                sender.send(data, timingOut: deadline) { closure in
+                    result {
+                        try closure()
+                    }
+                }
+            }
+            completion {
+                self = .asyncSender(closure)
+                return (self, closure)
+            }
+        case .asyncReceiver(let receiver):
+            let closure: ((AsyncStream, (Void throws -> Void) -> Void) -> Void) = { sender, result in
+                _ = AsyncDrain(for: receiver, timingOut: deadline) {
+                    do {
+                        let drain = try $0()
+                        sender.send(drain.data, timingOut: deadline, completion: result)
+                    } catch {
+                        result {
+                            throw error
+                        }
+                    }
+                }
+            }
+            completion {
+                self = .asyncSender(closure)
+                return (self, closure)
+            }
+        case .asyncSender(let closure):
+            completion {
+                (self, closure)
+            }
+        default:
+            completion {
+                throw BodyError.inconvertibleType
+            }
+        }
+    }
+    
+    ///Returns true if body is case `asyncSender`
+    public var isAsyncSender: Bool {
+        switch self {
+        case .asyncSender: return true
         default: return false
         }
     }

--- a/Sources/Body.swift
+++ b/Sources/Body.swift
@@ -233,9 +233,9 @@ extension Body {
             }
         case .asyncReceiver(let receiver):
             let closure: ((AsyncStream, ((Void) throws -> Void) -> Void) -> Void) = { sender, result in
-                _ = AsyncDrain(for: receiver, timingOut: deadline) {
+                _ = AsyncDrain(for: receiver, timingOut: deadline) { getData in
                     do {
-                        let drain = try $0()
+                        let drain = try getData()
                         sender.send(drain.data, timingOut: deadline, completion: result)
                     } catch {
                         result {

--- a/Tests/S4/BodyTests.swift
+++ b/Tests/S4/BodyTests.swift
@@ -7,6 +7,9 @@ class BodyTests: XCTestCase {
            ("testSender", testSender),
            ("testReceiver", testReceiver),
            ("testBuffer", testBuffer),
+           ("testAsyncReceiver", testAsyncReceiver),
+           ("testAsyncSender", testAsyncSender),
+           ("testThrowInconvertibleType", testThrowInconvertibleType),
         ]
     }
 
@@ -19,6 +22,17 @@ class BodyTests: XCTestCase {
 
         testBodyProperties(sender)
     }
+    
+    func testAsyncSender() {
+        let sender = Body.asyncSender { stream, completion in
+            stream.send(self.data) { closure in
+                completion {
+                    try closure()
+                }
+            }
+        }
+        testAsyncBodyProperties(sender)
+    }
 
     func testReceiver() {
         let drain = Drain(for: self.data)
@@ -26,11 +40,64 @@ class BodyTests: XCTestCase {
 
         testBodyProperties(receiver)
     }
+    
+    func testAsyncReceiver() {
+        let drain = AsyncDrain(for: self.data)
+        let receiver = Body.asyncReceiver(drain)
+        
+        testAsyncBodyProperties(receiver)
+    }
 
     func testBuffer() {
         let buffer = Body.buffer(self.data)
 
         testBodyProperties(buffer)
+    }
+    
+    func testThrowInconvertibleType(){
+        let sender = Body.sender { stream in
+            try stream.send(self.data)
+        }
+        
+        let drain = Drain(for: self.data)
+        let receiver = Body.receiver(drain)
+        
+        let tasks: [[(Void -> Void) -> Void]] = [sender, receiver].map { body in
+            var body = body
+            var tasks: [(Void -> Void) -> Void] = []
+            
+            tasks.append({ next in
+                body.becomeAsyncSender {
+                    do {
+                        try $0()
+                    } catch BodyError.inconvertibleType {
+                        next()
+                    } catch {
+                        XCTFail("Incorrect error type")
+                    }
+                }
+            })
+            
+            tasks.append({ next in
+                body.becomeAsyncReceiver {
+                    do {
+                        try $0()
+                    } catch BodyError.inconvertibleType {
+                        next()
+                    } catch {
+                        XCTFail("Incorrect error type")
+                    }
+                }
+            })
+            
+            return tasks
+        }
+        
+        waitForExpectations(delay: 1, withDescription: "testThrowInconvertibleType") { done in
+            XCTestCase.series(tasks: tasks.flatMap { $0 }) {
+                done()
+            }
+        }
     }
 
     private func testBodyProperties(_ body: Body) {
@@ -83,13 +150,132 @@ class BodyTests: XCTestCase {
             XCTFail("Incorrect type")
         }
     }
+    
+    private func testAsyncBodyProperties(_ body: Body) {
+        var bodyForAsyncBuffer = body
+        var bodyForAsyncReceiver = body
+        var bodyForAsyncSender = body
+        
+        waitForExpectations(delay: 1, withDescription: "testAsyncBodyProperties") { done in
+            let asyncBufferTask: (Void -> Void) -> Void = { callback in
+                bodyForAsyncBuffer.asyncBecomeBuffer {
+                    let (bodyForAsyncBuffer, d) = try! $0()
+                    XCTAssert(self.data == d, "Garbled buffer bytes")
+                    switch bodyForAsyncBuffer {
+                    case .buffer(let d):
+                        XCTAssert(self.data == d, "Garbled buffer bytes")
+                        callback()
+                    default:
+                        XCTFail("Incorrect type")
+                    }
+                }
+            }
+            
+            let asyncReceiverTask: (Void -> Void) -> Void = { callback in
+                
+                bodyForAsyncReceiver.becomeAsyncReceiver {
+                    var (bodyForAsyncReceiver, receiver) = try! $0()
+                    var tasks: [(Void -> Void) -> Void] = []
+                    
+                    tasks.append({ [unowned self] next in
+                        
+                        bodyForAsyncReceiver.forceReopenAsyncDrain {
+                            _ = AsyncDrain(for: receiver) {
+                                try! XCTAssert(self.data == $0().data, "Garbled buffer bytes")
+                                next()
+                            }
+                        }
+                    })
+                    
+                    tasks.append({ [unowned self] next in
+                        bodyForAsyncReceiver.forceReopenAsyncDrain {
+                            switch bodyForAsyncReceiver {
+                            case .asyncReceiver(let receiver):
+                                _ = AsyncDrain(for: receiver) {
+                                    try! XCTAssert(self.data == $0().data, "Garbled buffer bytes")
+                                    next()
+                                }
+                            default:
+                                XCTFail("Incorrect type")
+                            }
+                        }
+                    })
+                    
+                    XCTestCase.series(tasks: tasks) {
+                        callback()
+                    }
+                }
+            }
 
+            let asyncSenderTask: (Void -> Void) -> Void = { callback in
+                bodyForAsyncSender.becomeAsyncSender {
+                    let (bodyForAsyncSender, sender) = try! $0()
+                    var tasks: [(Void -> Void) -> Void] = []
+                    
+                    tasks.append({ [unowned self] next in
+                        bodyForAsyncReceiver.forceReopenAsyncDrain {
+                            let drain = AsyncDrain()
+                            sender(drain) {
+                                do {
+                                    try $0()
+                                    XCTAssert(self.data == drain.data, "Garbled buffer bytes")
+                                    next()
+                                } catch {
+                                    XCTFail("AsyncDrain threw error \(error)")
+                                }
+                            }
+                        }
+                    })
+                    
+                    tasks.append({ [unowned self] next in
+                        bodyForAsyncReceiver.forceReopenAsyncDrain {
+                            switch bodyForAsyncSender {
+                            case .asyncSender(let sender):
+                                let drain = AsyncDrain()
+                                sender(drain) {
+                                    do {
+                                        try $0()
+                                        XCTAssert(self.data == drain.data, "Garbled buffer bytes")
+                                        next()
+                                    } catch {
+                                        XCTFail("AsyncDrain threw error \(error)")
+                                    }
+                                }
+                            default:
+                                XCTFail("Incorrect type")
+                            }
+                        }
+                    })
+                    
+                    XCTestCase.series(tasks: tasks) {
+                        callback()
+                    }
+                    
+                }
+            }
+            
+            let tasks = [asyncBufferTask, asyncReceiverTask, asyncSenderTask]
+            
+            XCTestCase.series(tasks: tasks) {
+                done()
+            }
+        }
+    }
 }
 
 extension Body {
     mutating func forceReopenDrain() {
         if let drain = (try! self.becomeReceiver()) as? Drain {
             drain.closed = false
+        }
+    }
+    
+    mutating func forceReopenAsyncDrain(completion: Void -> Void) {
+        self.becomeAsyncReceiver {
+            let (_, stream) = try! $0()
+            let drain = stream as! AsyncDrain
+            drain.closed = false
+            completion()
         }
     }
 }

--- a/Tests/S4/BodyTests.swift
+++ b/Tests/S4/BodyTests.swift
@@ -62,9 +62,9 @@ class BodyTests: XCTestCase {
         let drain = Drain(for: self.data)
         let receiver = Body.receiver(drain)
         
-        let tasks: [[(Void -> Void) -> Void]] = [sender, receiver].map { body in
+        let tasks: [[((Void) -> Void) -> Void]] = [sender, receiver].map { body in
             var body = body
-            var tasks: [(Void -> Void) -> Void] = []
+            var tasks: [((Void) -> Void) -> Void] = []
             
             tasks.append({ next in
                 body.becomeAsyncSender {
@@ -157,7 +157,7 @@ class BodyTests: XCTestCase {
         var bodyForAsyncSender = body
         
         waitForExpectations(delay: 1, withDescription: "testAsyncBodyProperties") { done in
-            let asyncBufferTask: (Void -> Void) -> Void = { callback in
+            let asyncBufferTask: ((Void) -> Void) -> Void = { callback in
                 bodyForAsyncBuffer.asyncBecomeBuffer {
                     let (bodyForAsyncBuffer, d) = try! $0()
                     XCTAssert(self.data == d, "Garbled buffer bytes")
@@ -171,11 +171,11 @@ class BodyTests: XCTestCase {
                 }
             }
             
-            let asyncReceiverTask: (Void -> Void) -> Void = { callback in
+            let asyncReceiverTask: ((Void) -> Void) -> Void = { callback in
                 
                 bodyForAsyncReceiver.becomeAsyncReceiver {
                     var (bodyForAsyncReceiver, receiver) = try! $0()
-                    var tasks: [(Void -> Void) -> Void] = []
+                    var tasks: [((Void) -> Void) -> Void] = []
                     
                     tasks.append({ [unowned self] next in
                         
@@ -207,10 +207,10 @@ class BodyTests: XCTestCase {
                 }
             }
 
-            let asyncSenderTask: (Void -> Void) -> Void = { callback in
+            let asyncSenderTask: ((Void) -> Void) -> Void = { callback in
                 bodyForAsyncSender.becomeAsyncSender {
                     let (bodyForAsyncSender, sender) = try! $0()
-                    var tasks: [(Void -> Void) -> Void] = []
+                    var tasks: [((Void) -> Void) -> Void] = []
                     
                     tasks.append({ [unowned self] next in
                         bodyForAsyncReceiver.forceReopenAsyncDrain {
@@ -270,7 +270,7 @@ extension Body {
         }
     }
     
-    mutating func forceReopenAsyncDrain(completion: Void -> Void) {
+    mutating func forceReopenAsyncDrain(completion: (Void) -> Void) {
         self.becomeAsyncReceiver {
             let (_, stream) = try! $0()
             let drain = stream as! AsyncDrain

--- a/Tests/S4/XcTest.swift
+++ b/Tests/S4/XcTest.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    class func series(tasks tasks: [(Void -> Void) -> Void], completion: Void -> Void) {
+        var index = 0
+        func _series(_ current: ((Void -> Void) -> Void)) {
+            current {
+                index += 1
+                index < tasks.count ? _series(tasks[index]) : completion()
+            }
+        }
+        _series(tasks[index])
+    }
+    
+#if swift(>=3.0)
+    func waitForExpectations(delay sec: NSTimeInterval = 1, withDescription: String, callback: (Void -> Void) -> Void) {
+        let expectation = self.expectation(withDescription: withDescription)
+
+        let done = {
+            expectation.fulfill()
+        }
+        
+        callback(done)
+        
+        self.waitForExpectations(withTimeout: sec) {
+            XCTAssertNil($0, "Timeout of \(Int(sec)) exceeded")
+        }
+    }
+#else
+    func waitForExpectations(delay sec: NSTimeInterval = 1, withDescription: String, callback: (Void -> Void) -> Void) {
+        let expectation = self.expectationWithDescription(withDescription)
+
+        let done = {
+            expectation.fulfill()
+        }
+        
+        callback(done)
+        
+        waitForExpectationsWithTimeout(sec) {
+            XCTAssertNil($0, "Timeout of \(Int(sec)) exceeded")
+        }
+    }
+#endif
+}

--- a/Tests/S4/XcTest.swift
+++ b/Tests/S4/XcTest.swift
@@ -2,19 +2,19 @@ import Foundation
 import XCTest
 
 extension XCTestCase {
-    class func series(tasks tasks: [(Void -> Void) -> Void], completion: Void -> Void) {
+    class func series(tasks asyncTasks: [((Void) -> Void) -> Void], completion: (Void) -> Void) {
         var index = 0
-        func _series(_ current: ((Void -> Void) -> Void)) {
+        func _series(_ current: (((Void) -> Void) -> Void)) {
             current {
                 index += 1
-                index < tasks.count ? _series(tasks[index]) : completion()
+                index < asyncTasks.count ? _series(asyncTasks[index]) : completion()
             }
         }
-        _series(tasks[index])
+        _series(asyncTasks[index])
     }
     
 #if swift(>=3.0)
-    func waitForExpectations(delay sec: NSTimeInterval = 1, withDescription: String, callback: (Void -> Void) -> Void) {
+    func waitForExpectations(delay sec: NSTimeInterval = 1, withDescription: String, callback: ((Void) -> Void) -> Void) {
         let expectation = self.expectation(withDescription: withDescription)
 
         let done = {
@@ -28,7 +28,7 @@ extension XCTestCase {
         }
     }
 #else
-    func waitForExpectations(delay sec: NSTimeInterval = 1, withDescription: String, callback: (Void -> Void) -> Void) {
+    func waitForExpectations(delay sec: NSTimeInterval = 1, withDescription: String, callback: ((Void) -> Void) -> Void) {
         let expectation = self.expectationWithDescription(withDescription)
 
         let done = {


### PR DESCRIPTION
Hi, This is my first PR to the Open Swift.
I added `asyncReceiver` and `asyncSender` cases to the Body to handle the streaming response with AsyncStream.
**Preferentially, it has been careful to not break the sync apis**

[Slimane](https://github.com/noppoMan/Slimane) needs those(or something like that) as soon as possible.
Please review!

This PR depends on https://github.com/open-swift/C7/pull/25