### PR TITLE
Remove argument labels from Client /  AsyncClient

### DIFF
--- a/Sources/AsyncClient.swift
+++ b/Sources/AsyncClient.swift
@@ -1,3 +1,3 @@
 public protocol AsyncClient: AsyncResponder {
-    init(connectingTo uri: URI) throws
+    init(uri: URI) throws
 }

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -1,3 +1,3 @@
 public protocol Client: Responder {
-    init(connectingTo uri: URI) throws
+    init(uri: URI) throws
 }


### PR DESCRIPTION
Separated from https://github.com/open-swift/S4/pull/50

This should have been merged a long time ago alongside with  04-12 migration.