### PR TITLE
computed cookies

### DIFF
--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -4,17 +4,42 @@ public struct Request: Message {
     public var version: Version
     public var headers: Headers
     public var body: Body
-    public var cookies: [String: String]
     public var storage: [String: Any]
 
-    public init(method: Method, uri: URI, version: Version, headers: Headers, body: Body, cookies: [String: String]) {
+    public init(method: Method, uri: URI, version: Version, headers: Headers, body: Body) {
         self.method = method
         self.uri = uri
         self.version = version
         self.headers = headers
         self.body = body
-        self.cookies = cookies
         self.storage = [:]
+    }
+}
+
+extension Request {
+    public var cookies: [String: String] {
+        guard let string = headers["cookie"].first else {
+            return [:]
+        }
+
+        var cookies: [String : String] = [:]
+
+        let tokens = string.characters.split(separator: ";")
+
+        for token in tokens {
+            let cookieTokens = token.split(separator: "=", maxSplits: 1)
+
+            guard cookieTokens.count == 2 else {
+                continue
+            }
+
+            let name = String(cookieTokens[0])
+            let value = String(cookieTokens[1])
+
+            cookies[name] = value
+        }
+        
+        return cookies
     }
 }
 
@@ -29,40 +54,37 @@ public protocol RequestRepresentable {
 public protocol RequestConvertible: RequestInitializable, RequestRepresentable {}
 
 extension Request {
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Data = [], cookies: [String: String] = [:]) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Data = []) {
         self.init(
             method: method,
             uri: uri,
             version: Version(major: 1, minor: 1),
             headers: headers,
-            body: .buffer(body),
-            cookies: cookies
+            body: .buffer(body)
         )
 
         self.headers["Content-Length"] += body.count.description
     }
 
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Stream, cookies: [String: String] = [:]) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: Stream) {
         self.init(
             method: method,
             uri: uri,
             version: Version(major: 1, minor: 1),
             headers: headers,
-            body: .receiver(body),
-            cookies: cookies
+            body: .receiver(body)
         )
 
         self.headers["Transfer-Encoding"] = "chunked"
     }
 
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: (Stream) throws -> Void, cookies: [String: String] = [:]) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: (Stream) throws -> Void) {
         self.init(
             method: method,
             uri: uri,
             version: Version(major: 1, minor: 1),
             headers: headers,
-            body: .sender(body),
-            cookies: cookies
+            body: .sender(body)
         )
 
         self.headers["Transfer-Encoding"] = "chunked"

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,6 +6,7 @@ import XCTest
 XCTMain([
     testCase(ExampleTests.allTests),
     testCase(BodyTests.allTests)
+    testCase(RequestTests.allTests)
 ])
 
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,7 +5,7 @@ import XCTest
 
 XCTMain([
     testCase(ExampleTests.allTests),
-    testCase(BodyTests.allTests)
+    testCase(BodyTests.allTests),
     testCase(RequestTests.allTests)
 ])
 

--- a/Tests/S4/RequestTests.swift
+++ b/Tests/S4/RequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import S4
+
+class RequestTests: XCTestCase {
+    static var allTests : [(String, (RequestTests) -> () throws -> Void)] {
+        return [
+               ("testCookies", testCookies),
+        ]
+    }
+
+    func testCookies() {
+        let request = Request(headers: ["Cookie": "test=123;other-cookie=321"])
+
+        XCTAssert(request.cookies["test"] == "123", "Cookies did not parse")
+        XCTAssert(request.cookies["other-cookie"] == "321", "Cookies did not parse")
+    }
+    
+}


### PR DESCRIPTION
Makes `cookies` on `S4.Request` computed instead of stored.

This prevents duplicate storing of cookie information in both the headers and the cookies property.