### PR TITLE
Use a simple struct for response cookies to allow extensions and subscripting

### DIFF
--- a/Sources/Cookies.swift
+++ b/Sources/Cookies.swift
@@ -1,0 +1,61 @@
+public struct Cookies {
+    private var cookies = Set<Cookie>()
+
+    public init() { }
+
+    public init<Cookies: Sequence where Cookies.Iterator.Element == Cookie>(cookies: Cookies) {
+        for cookie in cookies {
+            self.cookies.insert(cookie)
+        }
+    }
+
+    public mutating func insert(_ cookie: Cookie) {
+        cookies.insert(cookie)
+    }
+
+    public mutating func remove(_ cookie: Cookie) {
+        cookies.remove(cookie)
+    }
+
+    public mutating func removeAll() {
+        cookies.removeAll()
+    }
+
+    public func contains(_ cookie: Cookie) -> Bool {
+        return cookies.contains(cookie)
+    }
+
+    public subscript(name: String) -> String? {
+        get {
+            guard let index = index(ofCookieNamed: name) else {
+                return nil
+            }
+
+            return cookies[index].value
+        }
+
+        set {
+            guard let value = newValue else {
+                if let index = index(ofCookieNamed: name) {
+                    cookies.remove(at: index)
+                }
+
+                return
+            }
+
+            cookies.insert(Cookie(name: name, value: value))
+        }
+    }
+
+    private func index(ofCookieNamed name: String) -> SetIndex<Cookie>? {
+        return cookies.index(where: { $0.name == name })
+    }
+}
+
+extension Cookies: Sequence {
+    public typealias Iterator = SetIterator<Cookie>
+
+    public func makeIterator() -> Iterator {
+        return cookies.makeIterator()
+    }
+}

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -3,10 +3,10 @@ public struct Response: Message {
     public var status: Status
     public var headers: Headers
     public var body: Body
-    public var cookies: Set<Cookie>
+    public var cookies: Cookies
     public var storage: [String: Any]
 
-    public init(version: Version, status: Status, headers: Headers, body: Body, cookies: Set<Cookie>) {
+    public init(version: Version, status: Status, headers: Headers, body: Body, cookies: Cookies) {
         self.version = version
         self.status = status
         self.headers = headers
@@ -27,7 +27,7 @@ public protocol ResponseRepresentable {
 public protocol ResponseConvertible: ResponseInitializable, ResponseRepresentable {}
 
 extension Response {
-    public init(status: Status = .ok, headers: Headers = [:], body: Data = [], cookies: Set<Cookie>) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Data = [], cookies: Cookies) {
         self.init(
             version: Version(major: 1, minor: 1),
             status: status,
@@ -39,7 +39,7 @@ extension Response {
         self.headers["Content-Length"] += body.count.description
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: Stream, cookies: Set<Cookie>) {
+    public init(status: Status = .ok, headers: Headers = [:], body: Stream, cookies: Cookies) {
         self.init(
             version: Version(major: 1, minor: 1),
             status: status,
@@ -51,7 +51,7 @@ extension Response {
         self.headers["Transfer-Encoding"] = "chunked"
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: (Stream) throws -> Void, cookies: Set<Cookie>) {
+    public init(status: Status = .ok, headers: Headers = [:], body: (Stream) throws -> Void, cookies: Cookies) {
         self.init(
             version: Version(major: 1, minor: 1),
             status: status,


### PR DESCRIPTION
This moves from a publically accessible `Set<Cookie>` to a new type, `Cookies`, that internally manage the same type. This is beneficial because it allows us to keep the simple, dictionary-esque cookie setting:

```
response.cookies["foo"] = "bar"
```

With it I included the core operations that people may use.

I did attempt to do this with extensions, but Swift just can't handle it quite yet. Hopefully down the road we can replace this with an extension on `Set where Element: Cookie`.