### PR TITLE
Only require the respective Stream type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
     name: "S4",
     dependencies: [
-        .Package(url: "https://github.com/open-swift/C7.git", majorVersion: 0, minor: 7),
+        .Package(url: "https://github.com/open-swift/C7.git", majorVersion: 0, minor: 8),
     ]
 )

--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -50,7 +50,7 @@ extension Request {
         self.headers["Transfer-Encoding"] = "chunked"
     }
 
-    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: (Stream) throws -> Void) {
+    public init(method: Method = .get, uri: URI = URI(path: "/"), headers: Headers = [:], body: (SendingStream) throws -> Void) {
         self.init(
             method: method,
             uri: uri,

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -46,7 +46,7 @@ extension Response {
         self.headers["Transfer-Encoding"] = "chunked"
     }
 
-    public init(status: Status = .ok, headers: Headers = [:], body: (Stream) throws -> Void) {
+    public init(status: Status = .ok, headers: Headers = [:], body: (SendingStream) throws -> Void) {
         self.init(
             version: Version(major: 1, minor: 1),
             status: status,


### PR DESCRIPTION
This is necessary as not all Stream functionality should be required to implement both Sending and Receiving. This change properly separates the requirements.

Depends on https://github.com/open-swift/C7/pull/43