### PR TITLE
fix stack over flow with self recursion

### DIFF
--- a/Sources/AsyncResponder.swift
+++ b/Sources/AsyncResponder.swift
@@ -12,6 +12,6 @@ public struct BasicAsyncResponder: AsyncResponder {
     }
 
     public func respond(to request: Request, result: @escaping ((Void) throws -> Response) -> Void) {
-        return self.respond(to: request, result: result)
+        return self.respond(request, result)
     }
 }

--- a/Sources/Responder.swift
+++ b/Sources/Responder.swift
@@ -22,6 +22,6 @@ public struct BasicResponder: Responder {
     }
 
     public func respond(to request: Request) throws -> Response {
-        return try self.respond(to: request)
+        return try self.respond(request)
     }
 }


### PR DESCRIPTION
This PR fixes segfault(stack over flow) in `BasicAsyncResponder.respond` and `Responder.respond` due to self recursion.
`Respond` and `AsyncRespond` no longer have labels so I removed them from `self.respond`.